### PR TITLE
Fixed the FOOTER on the gig-central/gigs/

### DIFF
--- a/application/views/gigs/index.php
+++ b/application/views/gigs/index.php
@@ -89,5 +89,4 @@
   </div>
 </div>
 
-</div>
 <?php $this->load->view($this->config->item('theme') . 'footer'); ?>


### PR DESCRIPTION
Removed an extra </div> tag to make the footer on this page line up with the rest of the layout. This file goes to 

application/views/gigs/index.php