### PR TITLE
Enhance gig details auth

### DIFF
--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -21,70 +21,81 @@
  * @todo
  */
  
-class Admin extends CI_Controller {
-         public function __construct()
-        {//begin constructor
-            parent::__construct();
-            $this->load->model('admin_model');
-            $this->load->library('form_validation');
-            $this->load->database();
-            $this->load->helper('form');
-            $this->load->library('email');
-		    //$this->load->helper('email');
-            //$this->load->library('session'); this will regenerate a new session everytime the constructor is called
-            // which will destroy the userData that is set when logging in!
-            //$this->load->library('recaptcha');
-            
-            $this->config->set_item('nav-active', 'Login');//sets active class on current nav item
-        }#end constructor
+class Admin extends CI_Controller 
+{
+    public function __construct()
+    {//begin constructor
+        parent::__construct();
+        $this->load->model('admin_model');
+        $this->load->library('form_validation');
+        $this->load->database();
+        $this->load->helper('form');
+        $this->load->library('email');
+        //$this->load->helper('email');
+        //$this->load->library('session'); //this will regenerate a new session everytime the constructor is called
+        // which will destroy the userData that is set when logging in!
+        //$this->load->library('recaptcha');
         
-        public function index(){
-            $data['title'] ="Admin dashboard";
-            if ($this->session->logged_in == TRUE){
-                $logged = 'Welcome to GigCentral website!';
-            }else{
-                $logged = 'You are logged out. Please come back soon!';
-            }
-            if (isset($this->session->first_name)){
-                $data['first_name'] = $this->session->first_name;   
-            }else{
-                $data['first_name'] = "";
-            }
-            
-            $data['logged'] = $logged;
-            $this->load->view('admins/index',$data);
+        $this->config->set_item('nav-active', 'Login');//sets active class on current nav item
+    }#end constructor
+        
+    public function index()
+    {
+        $data['title'] ="Admin dashboard";
+        if ($this->session->logged_in == TRUE){
+            var_dump($this->session->first_name);
+            die();
+            //$data['logged'] = 'Welcome to GigCentral website!';
+            $data['first_name'] = $this->session->first_name; 
+        }else{
+            $data['logged'] = 'You are logged out. Please come back soon!';
+            $data['first_name'] = "";
         }
-        public function login()
+
+        $this->load->view('admins/index',$data);
+    }
+
+    public function login()
+    {
+        $data['title'] = "Login page";        
+
+        //set validation rules
+        $this->form_validation->set_rules('email', 'Email', 'trim|required|valid_email');
+        $this->form_validation->set_rules('pass', 'Pass', 'trim|required');
+
+        if ($this->form_validation->run() === FALSE) 
+        { //no data yet, show form!
+            $this->load->view('admins/login',$data);    
+            
+            //set form data to NULL
+            $form_data = NULL;             
+        }else
         {
-            $data['title'] = "Login page";
-            if(!isset($_POST['Submit'])){
-                $data['error']='';
+        //form validation passed
+
+            //grab post data and insert into array
+            $form_data = array(
+            'email' => $this->input->post('email'),
+            'pass' => $this->input->post('pass')
+            );
+
+            if($this->admin_model->authenticate($form_data) === TRUE)
+            {//pasword is authenticated
+                //var_dump($this->session->first_name);
+                //die();
+                $data['logged'] = 'Welcome to GigCentral website!';
+                $data['first_name'] = $this->session->first_name; 
+
+                $this->load->view('admins/index',$data); 
+            }else
+            {//provide feedback and reload form
+                feedback('Invalid credentials', 'error'); 
+
                 $this->load->view('admins/login',$data);    
-            }else{
-                $this->form_validation->set_rules('email', 'Email', 'trim|required|valid_email');
-                $this->form_validation->set_rules('pass', 'Pass', 'trim|required',array(
-                    'required' => 'The password field is required'
-                ));
-                if ($this->form_validation->run() == FALSE) // validation hasn't been passed
-                { 
-                    $this->load->view('admins/login',$data);
-                    
-                }else{
-                    $form_data = array(
-                    'email' => set_value('email'),
-                    'pass' => set_value('pass')
-                    );
-                 if ($this->admin_model->getInfor($form_data)){
-                  $data['error'] = $this->admin_model->getInfor($form_data);   
-                 }else{
-                   $data['error']='';
-                 }
-                 $this->load->view('admins/login',$data);    
-                }
-                
-            }
-            
+            }   
         }
+    }            
+
 
         /**
          * requestReset method for Admin controller class. 

--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -43,9 +43,7 @@ class Admin extends CI_Controller
     {
         $data['title'] ="Admin dashboard";
         if ($this->session->logged_in == TRUE){
-            var_dump($this->session->first_name);
-            die();
-            //$data['logged'] = 'Welcome to GigCentral website!';
+            $data['logged'] = 'Welcome to GigCentral website!';
             $data['first_name'] = $this->session->first_name; 
         }else{
             $data['logged'] = 'You are logged out. Please come back soon!';

--- a/application/models/Admin_model.php
+++ b/application/models/Admin_model.php
@@ -28,35 +28,48 @@ class Admin_model extends CI_Model {
                 $this->load->library('email');
                 $this->load->library('encryption');
         }
+
         
-        public function getInfor($data)
+        /**
+         * authenticate method for Admin_model class. 
+         *
+         * @param string 
+         * @param $data will be checked against existing DB user data 
+         * @return boolean 
+         * @todo none
+         */ 
+        
+        public function authenticate($data)
         {
-           if ($data == ""){
-            return FALSE;
-            } else {
-            $query = $this->db->get_where('Profile', array('email' => $data['email']));
-            $row = $query->row();    
+           if (is_null($data)){
+                return FALSE;
+            } else 
+            {
+                $query = $this->db->get_where('Profile', array('email' => $data['email']));
+                $row = $query->row();    
+
                 if (isset($row))
                 {
                     if(password_verify($data['pass'], $row->password))
-                    {
-                    
-                    $newdata = array(
-                        'email' => $row->email,
-                        'id' => $row->id,
-                        'status'=> $row->i_am_a,
-                        'first_name'=> $row->first_name,
-                        'last_name'=> $row->last_name,
-                        'picture'=> $row->picture, 
-                        'logged_in' => TRUE,
-                        'bio'     => $row->bio,
-                    );
+                    {                   
+                        $newdata = array(
+                            'email' => $row->email,
+                            'id' => $row->id,
+                            'status'=> $row->i_am_a,
+                            'first_name'=> $row->first_name,
+                            'last_name'=> $row->last_name,
+                            'picture'=> $row->picture, 
+                            'logged_in' => TRUE,
+                            'bio'     => $row->bio,
+                        );
+        
                         $this->load->library('session');
-                        $this->session->set_userdata($newdata); 
-                        redirect('admin/');
-                    }else{
-                        $error = 'The password and email is not match';
-                        return $error;
+                        $this->session->set_userdata($newdata);
+                         
+                        return TRUE;
+                    }else
+                    {
+                        return FALSE;
                     
                     }
                 }

--- a/application/views/admins/login.php
+++ b/application/views/admins/login.php
@@ -39,7 +39,6 @@
                 <input type="password" class="form-control" id="Pass" name="pass" placeholder="Password">
             </div>
             <?php echo form_error('pass'); ?>
-            <?php echo $error; ?>
 
             <a href="<?=base_url()?>admin/reset">Forgot Password?</a><br>
 


### PR DESCRIPTION
This pull request is related to issue #151 and #203.

This commit:

- refactor the Admin controller's login() and index() methods
- adds bootswatch feedback
- form is not submitted if form validation is not passed
- makes the log in work

Setbacks: Authentication (loging) works. However the session with user data is not persisting. So, sessions might have to become a separate issue. **see issue 151 comments**: sessions is working for some
Once the Session handling is debugged, the Admin navigation should display. The logic for toggling the admin navigation/ non-admin navigation is in application/libraires/Navigation.php:
https://github.com/gig-central/gig-repo-1/blob/de65e97d4bfd6d33bb47631fb329fee3a1ca6123/application/libraries/Navigation.php#L119
![20190531_041028](https://user-images.githubusercontent.com/26440947/58703470-a8480480-835d-11e9-9233-d46f44bab5d8.gif)
