### PR TITLE
Removes login warning and form field redundancy

### DIFF
--- a/application/views/gigs/add.php
+++ b/application/views/gigs/add.php
@@ -21,8 +21,6 @@
 
 <?php $this->load->view($this->config->item('theme') . 'header'); ?>
 
-<h1>Please note, if you do not login or create an account before posting a gig, you will be unable to make changes to or delete it after it has been posted</h1>
-
 <div class="container">
     <div class="col-lg-10">
         <form class="form-horizontal" role="form" method="post" action="add">
@@ -59,14 +57,14 @@
                 </div>
                 <div class="form-group">
                     <label for="CompanyState" class="col-lg-3 control-label"><em>State</em></label>
-                    <div class="col-md-6"> 
+                    <div class="col-md-6">
                         <?php echo form_error('CompanyState'); ?>
                         <!--php tag with eco starts here to avoid having echo in the middle of the makeDropdownSelect() function -->
                         <?php echo '
                         <select class="form-control" id="CompanyState" name="CompanyState">
                             <option value="0">Select State</option>' .
                             //insert <option> elements
-                            makeDropdownSelect($this->config->item("stateSelect")) . ' 
+                            makeDropdownSelect($this->config->item("stateSelect")) . '
                         </select>'; ?>
                     </div>
                 </div>
@@ -146,7 +144,7 @@
                 </div>
                 <div class="form-group">
                     <label for="GigCloseDate"class="col-lg-3 control-label hidden-label">
-                        <em>Gig Close Date</em>
+                        <em>Close Date</em>
                     </label>
                     <div class="col-md-6">
                         <?php
@@ -157,21 +155,21 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="GigOutline" class="col-lg-3 control-label hidden-label"><em>Gig Description</em></label>
+                    <label for="GigOutline" class="col-lg-3 control-label hidden-label"><em>Description</em></label>
                     <div class="col-md-6">
                         <?php echo form_error('GigOutline'); ?>
                         <textarea class="form-control" rows="15" cols="25" id="GigOutline" name="GigOutline" placeholder="Project/Gig Description"><?php echo set_value('GigOutline'); ?></textarea>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="GigQualify" class="col-lg-3 control-label hidden-label"><em>Gig Qualifications</em></label>
+                    <label for="GigQualify" class="col-lg-3 control-label hidden-label"><em>Qualifications</em></label>
                     <div class="col-md-6">
                         <?php echo form_error('GigQualify'); ?>
                         <textarea  rows="15" cols="25" class="form-control" id="GigQualify" name="GigQualify" placeholder="Qualifications"><?php echo set_value('GigQualify'); ?></textarea>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="SpInstructions" class="col-lg-3 control-label hidden-label"><em>Gig Special Instructions</em></label>
+                    <label for="SpInstructions" class="col-lg-3 control-label hidden-label"><em>Special Instructions</em></label>
                     <div class="col-md-6">
                         <?php echo form_error('SpInstructions'); ?>
                         <textarea rows="15" cols="25" class="form-control" id="SpInstructions" name="SpInstructions" placeholder="Special Instructions"><?php echo set_value('SpInstructions'); ?></textarea>


### PR DESCRIPTION
Removes warning about deprecated login feature and form label redundancy. Corresponds with Issue [201](https://github.com/gig-central/gig-repo-1/issues/201). You can see the changes in effect on the Add a Gig page.