### PR TITLE
gig details removed from public view

### DIFF
--- a/application/controllers/Gig.php
+++ b/application/controllers/Gig.php
@@ -90,16 +90,32 @@ class Gig extends CI_Controller
     }#end function index
 
     public function view($slug = NULL)
-    {//begin function index
-        $data['userId'] = $this->gig_model->get_session_id();
-        $data['gig'] = $this->gig_model->getGigs($slug);
-        if (empty($data['gig']))
-        {
-            show_404();
-        }
+    {//begin function view
+        $this->load->model('admin_model');
+        $this->load->database();
         $data['title']= 'Gig';
 
-        $this->load->view('gigs/view', $data);
+        if($this->session->logged_in === TRUE)
+        {//if logged get data of the gig(s) that matches userId from db)
+            $data['userId'] = $this->gig_model->get_session_id();
+            $data['gig'] = $this->gig_model->getGigs($slug);
+            if (empty($data['gig']))
+            {
+                show_404();
+            }
+
+            $this->load->view('gigs/view', $data);
+        }else
+        {
+            feedback(
+                '<p class="text-primary">Please log in to see gig details</p>'
+                , 'warning'
+            ); //set feedback
+            $data['gigs'] = $this->gig_model->getGigs();
+            $data['title']= 'Gigs';
+
+            $this->load->view('gigs/index', $data);
+        }
     }#end function view
 
     public function edit(){

--- a/application/views/gigs/view.php
+++ b/application/views/gigs/view.php
@@ -12,7 +12,7 @@
 * @license http://www.apache.org/licenses/LICENSE-2.0
 * @see Gig_model.php
 * @see Gig.php
-* @todo none
+* @todo limit this view to authenticated students only. 
 */
 ?>
     <?php $this->load->view($this->config->item('theme') . 'header'); ?>


### PR DESCRIPTION
This commit fixes issues #203 .

- gig details are no longer visible to the public 
- gig details will only load after user has logged in
- The user is given feedback with bootswatch styles.


To view fixes: 
- go to find gigs/ click on "read more"

See: fixes on my instance: https://www.tegs.tech/gig-central/gig
