### PR TITLE
makeDropdownSelect() is now generic

### DIFF
--- a/application/config/custom_config_sample.php
+++ b/application/config/custom_config_sample.php
@@ -124,3 +124,11 @@ $config['stateSelect'] = array(
     'WV' => 'West Virginia',
     'WY' => 'Wyoming',
 );
+
+// dropdown employment type selection used with makeDropdownSelect() for employment type selection
+$config['employmentTypeSelect'] = array(
+    'contract'  => 'Contract',
+    'intern'    => 'Intern',
+    'temporary' => 'Temporary',
+    'permanent' => 'Permanent',
+);

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -154,37 +154,50 @@ return $decrypted;
  * makeDropdownSelect($option) inserts dropdown <option> elements
  * this function is written generically and can be applied to any dropdown
  * 
- *
+ * function implementation example:
  * <code>
  *    <?php echo '
  *        <select class="form-control" id="CompanyState" name="CompanyState">
  *            <option value="0">Select State</option>' .
- *            makeDropdownSelect($this->config->item("stateSelect")) . ' 
+ *            makeDropdownSelect($this->config->item("stateSelect"),"CompanyState") . ' 
  *        </select>'; 
  *     ?>
  * </code>
  *
+ * array implementation example
+ * <code>
+ *    $config['stateSelect'] = array(
+ *        'AK' => 'Alaska',
+ *        'AL' => 'Alabama',
+ *        'WV' => 'West Virginia',
+ *        'WY' => 'Wyoming',
+ *    );
+ * <code>
+ *
  * @param string $option is an array of key/value pairs
+ * @param string $fieldSetName is the name property value of the select element
  * 
  * @return string $myReturn is a fully formatted <option> element
  *
  * @see related custom validation message used is
- * @see controller function __construct:         $this->form_validation->set_message('check_dropdown', 'The {field} must be selected.');
- * @see form_validation.php: 'rules' => 'required|callback_check_dropdown' for field used
+ * @see      controller function __construct:         
+ * @see      $this->form_validation->set_message('check_dropdown', 'The {field} must be selected.');
+ * @see      form_validation.php: 'rules' => 'required|callback_check_dropdown' for field used
  *
+ 
+ 
  * @todo none
  */
 
 
 if(!function_exists('makeDropdownSelect'))
 {
-    function makeDropdownSelect($option)
+    function makeDropdownSelect($option,$fieldSetName)
     {
         $myReturn = '';
-        foreach ($option as $key => $value)
-        
+        foreach ($option as $key => $value)        
         {            
-            $myReturn .= '<option value="' . $key . '"' . set_select("CompanyState", "$key") . '>' . $value . '</option>' . PHP_EOL;
+            $myReturn .= '<option value="' . $key . '"' . set_select("$fieldSetName", "$key") . '>' . $value . '</option>' . PHP_EOL;
         }
         return $myReturn;
             

--- a/application/views/gigs/add.php
+++ b/application/views/gigs/add.php
@@ -60,13 +60,13 @@
                     <div class="col-md-6">
 <!--
                         See implmentaion instructions in the makeDropdownSelect() function documention in helpers/common_helpers.php
-                        Also, be sure the state key/value array is in the custom_config.php file as shoule in custom_config_sample.php
+                        Also, be sure the stateSelect key/value array is in the custom_config.php file as shown in custom_config_sample.php
 -->
                         <?php echo form_error('CompanyState'); ?>
                         <?php echo '
                         <select class="form-control" id="CompanyState" name="CompanyState">
                             <option value="0">Select State</option>' . 
-                            makeDropdownSelect($this->config->item("stateSelect")) . ' 
+                            makeDropdownSelect($this->config->item("stateSelect"), "CompanyState") . ' 
                         </select>'; ?>
                     </div>
                 </div>
@@ -125,17 +125,20 @@
                 <div class="form-group">
                     <legend><h3><strong>Gig Information</strong></h3></legend>
                 </div>
+<!--
+                See implmentaion instructions in the makeDropdownSelect() function documention in helpers/common_helpers.php
+                Also, be sure the empolymentType key/value array is in the custom_config.php file as shown in custom_config_sample.php
+-->    
                 <div class="form-group">
                     <label for="EmploymentType" class="col-lg-3 control-label"><em>Employment Type</em></label>
                     <div class="col-md-6">
                         <?php echo form_error('EmploymentType'); ?>
-                        <select class="form-control" id="EmploymentType" name="EmploymentType">
-                            <option value="0">Select One</option>
-                            <option value="contract" <?php echo set_select('EmploymentType', 'contract'); ?>>Contract</option>
-                            <option value="intern" <?php echo set_select('EmploymentType', 'intern'); ?>>Intern</option>
-                            <option value="temporary" <?php echo set_select('EmploymentType', 'temporary'); ?>>Temporary</option>
-                            <option value="permanent" <?php echo set_select('EmploymentType', 'permanent'); ?>>Permanent</option>
-                        </select>
+                        <?php echo '
+                            <select class="form-control" id="EmploymentType" name="EmploymentType">
+                                <option value="0">Select One</option>' .
+                                 makeDropdownSelect($this->config->item("employmentTypeSelect"),"EmploymentType") . ' 
+                            </select>'; 
+                        ?>
                     </div>
                 </div>
                 <div class="form-group">


### PR DESCRIPTION
makeDropdownSelect() is now generic. It has also been implemented for EmploymentType as well as CompanyState to validate it does work for different selects.

See working code: https://kiseharrington.com/gig-central/gig/add

One other thing ... Developers must add the employmentTypeSelect array to their custom_config.php. it's a copy from sample_custom_config.php lines 128-134