### PR TITLE
Standardize button styles

### DIFF
--- a/application/views/admins/login.php
+++ b/application/views/admins/login.php
@@ -36,9 +36,7 @@
             </div>
             <?php echo form_error('pass'); ?>
 
-            <a href="<?=base_url()?>admin/reset">Forgot Password?</a><br>
-
-            <div class="form-group">
+            <div class="form-group text-center">
                 <button type="submit" class="btn" name="Submit">Submit</button>
             </div>
         </form>

--- a/application/views/admins/login.php
+++ b/application/views/admins/login.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
 * login.php is the login admins page for Admin controller
@@ -7,8 +6,8 @@
 *
 * @package itc-260-sp15-gig-central
 * @subpackage Admin Controller
-* @author Rattana Neak
-* @version 1.0 2016/05/22
+* @author Rattana Neak, Craig Peterson <craig.peterson@seattlecentral.edu>
+* @version 1.1 2019/06/03
 * @link
 * @license http://www.apache.org/licenses/LICENSE-2.0
 * @see Admin_model.php
@@ -16,10 +15,6 @@
 * @todo none
 */
 ?>
-
-
-
-
 
 <?php $this->load->view($this->config->item('theme').'header'); ?>
 
@@ -37,19 +32,21 @@
             <div class="form-group">
                 <label for="Pass" class="col-lg-3 control-label hidden">Password:</label>
                 <input type="password" class="form-control" id="Pass" name="pass" placeholder="Password">
+                <a href="<?=base_url()?>admin/reset">Forgot Password?</a>
             </div>
             <?php echo form_error('pass'); ?>
             <?php echo $error; ?>
 
-            <a href="<?=base_url()?>admin/reset">Forgot Password?</a><br>
+            <div class="form-group text-center">
+                <button type="submit" class="btn" name="Submit">Submit</button>
+            </div>
 
-            <h2 class="member">Not A Member?</h2><br>
-            <a href="<?=base_url()?>profiles/add">Register</a>
-
-            <div class="form-group">
-                <button type="submit" class="btn btn-default btn-block" name="Submit">Submit</button>
+            <div class="custom-info-box">
+                <h2 class="h4">Not A Member?</h2><!-- bootstrap h4 class reduces font-size -->
+                <a href="<?=base_url()?>profiles/add">Register</a>
             </div>
         </form>
     </div><!-- end row form -->
 </div><!-- end .container -->
+
 <?php $this->load->view($this->config->item('theme').'footer'); ?>

--- a/application/views/admins/login.php
+++ b/application/views/admins/login.php
@@ -42,7 +42,7 @@
             </div>
 
             <div class="custom-info-box">
-                <h2 class="h4">Not A Member?</h2><!-- bootstrap h4 class reduces font-size -->
+                <h4>Not A Member?</h4>
                 <a href="<?=base_url()?>profiles/add">Register</a>
             </div>
         </form>

--- a/application/views/gigs/add.php
+++ b/application/views/gigs/add.php
@@ -65,8 +65,8 @@
                         <?php echo form_error('CompanyState'); ?>
                         <?php echo '
                         <select class="form-control" id="CompanyState" name="CompanyState">
-                            <option value="0">Select State</option>' . 
-                            makeDropdownSelect($this->config->item("stateSelect")) . ' 
+                            <option value="0">Select State</option>' .
+                            makeDropdownSelect($this->config->item("stateSelect")) . '
                         </select>'; ?>
                     </div>
                 </div>
@@ -181,7 +181,7 @@
                 <div class="form-group text-right">
                     <div class="col-lg-3"></div>
                     <div class="col-lg-6">
-                        <?php echo form_submit('Submit', 'Add',"class='btn btn-success'"); ?>
+                        <?php echo form_submit('Submit', 'Add',"class='btn'"); ?>
                     </div>
                 </div>
 

--- a/application/views/gigs/index.php
+++ b/application/views/gigs/index.php
@@ -43,7 +43,7 @@
                 <div class="form-group">
                     <input type="text" class="form-control" placeholder="Enter a Keyword..." name="keyword">
                 </div>
-                <button type="submit" class="btn">Search</button>
+                <button type="submit" class="btn small-btn">Search</button>
             </form>
 
             <!-- gig filter form -->
@@ -79,7 +79,7 @@
                     </label>
                 </div>
 
-                <button type="submit" class="btn">Filter</button>
+                <button type="submit" class="btn small-btn">Filter</button>
 
             </form>
         </div><!-- .col-sm-6 -->

--- a/application/views/gigs/index.php
+++ b/application/views/gigs/index.php
@@ -6,8 +6,8 @@
 *
 * @package ITC 260 Gig Central CodeIgnitor
 * @subpackage Gig Controller
-* @author Patricia Barker <pbarke01@seattlecentral.edu>
-* @version 1.0 2015/05/25
+* @author Patricia Barker <pbarke01@seattlecentral.edu>, Craig Peterson <craig.peterson@seattlecentral.edu>
+* @version 1.1 2019/06/03
 * @link http://www.tcbcommercialproperties.com/sandbox/ci/
 * @license http://www.apache.org/licenses/LICENSE-2.0
 * @see Gig_model.php
@@ -17,6 +17,7 @@
 ?>
 
 <?php $this->load->view($this->config->item('theme') . 'header'); ?>
+
 <?php if(isset($_POST['submit'])) {
     $retrived_result = $gig->filter($_POST);
 }?>
@@ -26,69 +27,77 @@
   <li class="active">Gigs</li>
 </ul>
 
+<h2 class="page-title">Gigs List</h2>
 
-<h2>Gigs List</h2>
-
-<form class="navbar-form navbar-left" role="search" method="post" action="gig/search">
-        <div class="form-group">
-          <input type="text" class="form-control" placeholder="Enter a Keyword..." name="keyword">
-        </div>
-        <button type="submit" class="btn-gigs-list">Submit</button>
-</form>
-<br>
 <div class="container-fluid">
-<h1>&nbsp;</h1>
-  <div class="row">
+    <!-- why is this here?
+    <h1>&nbsp;</h1>
+    -->
+    <div class="row">
 
-    <div class="col-sm-6">
-        <?php foreach ($gigs as $gig): ?>
-        <h3><?php echo $gig['Name'] ?></h3>
-        <p><?php echo $gig['CompanyCity'] . ", " . $gig['State'] ?></p>
-        <p><?php echo $gig['GigOutline'] ?></p>
-        <p><?php echo anchor('gig/'.$gig['GigID'] , 'Read More');?></p>
-        <?php endforeach ?>
-      </div>
+        <!-- right column: search form and filter form -->
+        <div class="col-sm-3 gig-search">
+            <!-- gig search field -->
+            <form role="search" method="post" action="gig/search">
+                <h4>Search by Keyword</h4>
+                <div class="form-group">
+                    <input type="text" class="form-control" placeholder="Enter a Keyword..." name="keyword">
+                </div>
+                <button type="submit" class="btn">Search</button>
+            </form>
 
-    <div class="col-sm-6">
-        <h2>Filter</h2>
-        <form role="filter" method="post" action="gig/filter">
-        <div class="form-group">
-        <label>Type of Job:
-          <select name="GigOutline">
+            <!-- gig filter form -->
+            <form role="filter" method="post" action="gig/filter">
+                <h4>Filter</h4>
+                <div class="form-group">
+                    <label>Type of Job:<br />
+                        <select name="GigOutline">
+                            <?php foreach ($gigs as $gig): ?>
+                            <option value="<?=$gig['GigOutline']?>"><?=$gig['GigOutline']?></option>
+                            <?php endforeach ?>
+                        </select>
+                    </label>
+                </div>
+
+                <div class="form-group">
+                    <label>City:<br />
+                        <select name="CompanyCity">
+                            <?php foreach ($gigs as $gig): ?>
+                            <option value="<?=$gig['CompanyCity']?>"><?=$gig['CompanyCity']?></option>
+                            <?php endforeach ?>
+                        </select>
+                    </label>
+                </div>
+
+                <div class="form-group">
+                    <label>Company Name:<br />
+                        <select name="Name">
+                            <?php foreach ($gigs as $gig): ?>
+                            <option value="<?=$gig['Name']?>"><?=$gig['Name']?></option>
+                            <?php endforeach ?>
+                        </select>
+                    </label>
+                </div>
+
+                <button type="submit" class="btn">Filter</button>
+
+            </form>
+        </div><!-- .col-sm-6 -->
+        <!-- END right column: search form and filter form -->
+
+        <!-- left column: lists all gigs -->
+        <div class="col-sm-9 gig-list">
             <?php foreach ($gigs as $gig): ?>
-              <option value="<?=$gig['GigOutline']?>"><?=$gig['GigOutline']?></option>
+                <div class="gig-list-item">
+                    <h3><?php echo $gig['Name'] ?></h3>
+                    <p><?php echo $gig['CompanyCity'] . ", " . $gig['State'] ?></p>
+                    <p><?php echo $gig['GigOutline'] ?></p>
+                    <p><?php echo anchor('gig/'.$gig['GigID'] , 'Read More');?></p>
+                </div>
             <?php endforeach ?>
-            </select></label>
-            </div>
+        </div>
 
-
-
-
-        <div class="form-group">
-        <label>City:
-          <select name="CompanyCity">
-            <?php foreach ($gigs as $gig): ?>
-              <option value="<?=$gig['CompanyCity']?>"><?=$gig['CompanyCity']?></option>
-            <?php endforeach ?>
-            </select></label>
-            </div>
-
-
-
-        <div class="form-group">
-        <label>Company Name:
-          <select name="Name">
-            <?php foreach ($gigs as $gig): ?>
-              <option value="<?=$gig['Name']?>"><?=$gig['Name']?></option>
-            <?php endforeach ?>
-            </select></label>
-            </div>
-            <div>
-               <button type="submit" class="btn-gigs-list">Go</button>
-            </div>
-        </form>
-      </div>
-  </div>
-</div>
+    </div><!-- .row -->
+</div><!-- .container-fluid -->
 
 <?php $this->load->view($this->config->item('theme') . 'footer'); ?>

--- a/public/css/custom_styles.css
+++ b/public/css/custom_styles.css
@@ -1,3 +1,21 @@
+/**
+ * public/css/custom_styles.css
+ *
+ * css styles for forms
+ *
+ * @package GigCentral
+ * @subpackage Home
+ * @author Elizabeth Jones, Craig Peterson <craig.peterson@seattlecentral.edu>
+ * @version 1.1 2019/06/03
+ * @link
+ * @license http://www.apache.org/licenses/LICENSE-2.0
+ * @see application/view/themes/bootswatch/header.php
+ * @todo none
+ */
+
+h2 {
+    padding-bottom:2rem;
+}
 
 .text-xs-center {
         text-align: center;
@@ -15,11 +33,12 @@ input#userfile {
     height: auto;
 }
 
-/*-------FAQ Accordian CSS------- */
+/*-------FAQ Accordian CSS-------*/
 .FAQ-wrapper {
 	margin: auto;
 	width: 75%;
 }
+
 .half {
 	float: left;
 	width: 100%;
@@ -27,30 +46,65 @@ input#userfile {
 }
 
   /* Accordian styles */
-  .tab {
+.tab {
 	position: relative;
 	margin-bottom: 1px;
 	width: 100%;
 	color: #fff;
 	overflow: hidden;
-  }
+}
 
-  .blue label {
+.blue label {
 	background: #2980b9;
-  }
-  .tab-content {
+}
+
+.tab-content {
 	max-height: 0;
 	overflow: hidden;
 	background: #1abc9c;
 	-webkit-transition: max-height .35s;
 	-o-transition: max-height .35s;
 	transition: max-height .35s;
-  }
-  .blue .tab-content {
+}
+
+.blue .tab-content {
 	background: #3498db;
-  }
-  .tab-content p {
+}
+
+.tab-content p {
 	margin: 1em;
 	  height: auto;
-  }
+}
 
+
+/*-------GIG LIST STYLES-------*/
+.gig-search form {
+    margin-top: 2rem;
+}
+
+.gig-search form:first-of-type {
+    margin-top:0;
+    padding-top:0;
+}
+
+.gig-search h4 {
+    margin-top:0;
+}
+
+.gig-list {
+    border-left: 2px solid #2c3e4f;
+}
+
+.gig-list h3:first-of-type {
+    margin-top:0;
+}
+
+.gig-list-item {
+    padding: 1rem;
+    background: #fff;
+    margin: 1rem 0;
+}
+
+.gig-list-item:first-of-type {
+    margin-top:0;
+}

--- a/public/css/custom_styles_forms.css
+++ b/public/css/custom_styles_forms.css
@@ -20,20 +20,19 @@
 }
 
 /* .container .btn - general button styles */
-.container .btn {
+.btn {
     background-color: #2c3e50;
     color: #fff;
     font-size: 1.5em;
     border: none;
 }
 
-.container .btn:hover {
+.btn:hover {
     background-color: #000;
 }
 
-/* gig-search and gig-filter buttons styles */
-.gig-search .btn,
-.gig-filter .btn {
+/* for when a slightly smaller button is desired */
+.small-btn {
     font-size: 1.2em;
     padding: 8px 12px;
 }
@@ -42,7 +41,7 @@
     margin-top:-10px; /* reduces space between last form field and submit button */
 }
 
-/* lines up a link that is above/below a form input field
+/* aligns text/links that are above/below a form input field
    with the text in the input field */
 .form-group a {
     margin-left:15px;

--- a/public/css/custom_styles_forms.css
+++ b/public/css/custom_styles_forms.css
@@ -1,92 +1,112 @@
 /**
  * public/css/custom_styles_forms.css
  *
- * css style for forms
+ * css styles for forms
  *
  * @package GigCentral
  * @subpackage Home
- * @author Elizabeth Jones
- * @version 1.0 2019/5/16
+ * @author Elizabeth Jones, Craig Peterson <craig.peterson@seattlecentral.edu>
+ * @version 1.1 2019/06/03
  * @link
  * @license http://www.apache.org/licenses/LICENSE-2.0
  * @see application/view/themes/bootswatch/header.php
  * @todo none
  */
 
-
 .form-actions {
     margin: 0;
     background-color: transparent;
     text-align: center;
-
 }
 
-.member {
-    font-size: 20px;
-}
-
+/* .container .btn - general button styles */
 .container .btn {
     background-color: #2c3e50;
-    color: white;
-    font-size: 1.8em;
-    padding: 12px 24px;
+    color: #fff;
+    font-size: 1.5em;
     border: none;
-    cursor: pointer;
-    border-radius: 15px;
-    text-align: center;
-    width: 50%;
-    margin-left: auto;
-    margin-right: auto;
-    margin-top: 5px;
 }
 
 .container .btn:hover {
-    background-color: black;
+    background-color: #000;
+}
+
+/* gig-search and gig-filter buttons styles */
+.gig-search .btn,
+.gig-filter .btn {
+    font-size: 1.2em;
+    padding: 8px 12px;
+}
+
+.form-group + button { /* targets a button that is immediately after a .form-group */
+    margin-top:-10px; /* reduces space between last form field and submit button */
+}
+
+/* lines up a link that is above/below a form input field
+   with the text in the input field */
+.form-group a {
+    margin-left:15px;
+}
+
+/* styles a custom-info-box that is inside a form */
+form .custom-info-box {
+    margin-top: 30px; /* doubles standard form-group spacing */
+}
+
+.custom-info-box {
+    background: #dee3e4; /* slightly darker than bootswatch flatly "well" class background */
+    border-left:5px solid #18bc9c;
+    padding: 1rem;
+}
+
+/* removes margins on the <h2> inside the .custom-info-box box */
+.custom-info-box h2 {
+    margin:0;
 }
 
 .contact-btn {
     margin-left: 180px;
 }
 
- label {
-	position: relative;
-	display: block;
-	padding: 0 2em 0 .5em;
-	background: #16a085;
-	font-weight: bold;
-	line-height: 2.5em;
-	cursor: pointer;
-  }
+label {
+    position: relative;
+    display: block;
+    padding: 0 2em 0 .5em;
+    background: #16a085;
+    font-weight: bold;
+    line-height: 2.5em;
+    cursor: pointer;
+}
 
-  label::after {
-	position: absolute;
-	right: 0;
-	top: 0;
-	display: block;
-	width: 3em;
-	line-height: 3;
-	text-align: center;
-	-webkit-transition: all .35s;
-	-o-transition: all .35s;
-	transition: all .35s;
-  }
+label::after {
+    position: absolute;
+    right: 0;
+    top: 0;
+    display: block;
+    width: 3em;
+    line-height: 3;
+    text-align: center;
+    -webkit-transition: all .35s;
+    -o-transition: all .35s;
+    transition: all .35s;
+}
 
-  input[type=checkbox] + label::after {
-	content: "+";
-  }
-  input[type=radio] + label::after {
-	content: "\25BC";
-  }
-  input[type=checkbox]:checked + label::after {
-	transform: rotate(315deg);
-  }
-  input[type=radio]:checked + label::after {
-	transform: rotateX(180deg);
-  }
+input[type=checkbox] + label::after {
+    content: "+";
+}
+input[type=radio] + label::after {
+    content: "\25BC";
+}
+input[type=checkbox]:checked + label::after {
+    transform: rotate(315deg);
+}
+input[type=radio]:checked + label::after {
+    transform: rotateX(180deg);
+}
 
- input:checked ~ .tab-content {
-	max-height: 15em;
-  }
+input:checked ~ .tab-content {
+    max-height: 15em;
+}
 
 @media (max-width: 425px) {
 	.g-recaptcha{


### PR DESCRIPTION
These changes simplify and standardize button styles across MVP pages. Additionally, a [style guide](https://docs.google.com/document/d/19PxRlB8ITMTzURyw9CoRoStEzH7l2cnIPXP0MRPFNaI/edit) has been started which documents how to implement buttons on future pages. Put simply, all you need to do is utilize the existing **.btn** class, which is part of the Bootswatch Flatly Theme, and has been customized for Gig Central in the [custom_styles_forms.css](https://github.com/gig-central/gig-repo-1/blob/master/public/css/custom_styles_forms.css) file. 

There is also a new **.small-btn** class that can be used in conjunction with the **.btn** class if a smaller button is desired. This can be seen on the Find a Gig page.

Finally, this pull request also updates the layout of the Find a Gig page. @jenevascherr has plans to further improve the layout, but we agreed to use this as a starting point.