### PR TITLE
Removed Gigs dropdown from nav and fixed nav-active

### DIFF
--- a/application/controllers/Gig.php
+++ b/application/controllers/Gig.php
@@ -49,9 +49,9 @@ class Gig extends CI_Controller
         parent::__construct();
         $this->load->model('Gig_model');
         $this->config->set_item('banner', 'Global News Banner');
-        $this->config->set_item('nav-active', 'Gigs');//sets active class on all gig children
         $this->load->helper('form');
         $this->load->library('form_validation');
+   
 
         /**
         *$this->form_validation->set_message below is a customer message for dropdown fields. This is basically
@@ -71,6 +71,7 @@ class Gig extends CI_Controller
         $data['gigs'] = $this->gig_model->getGigs();
         $data['title']= 'Gigs';
 
+        $this->config->set_item('nav-active', 'Find a Gig');
         $this->load->view('gigs/index', $data);
     }#end function index
 
@@ -192,6 +193,7 @@ class Gig extends CI_Controller
 
     public function add()
     {
+        $this->config->set_item('nav-active', 'Post a Gig');
         $data['title'] = 'Add a New Gig'; //set values to be passed to view
 
         //establish form validation rules is handled in config/form_validation.php

--- a/application/libraries/Navigation.php
+++ b/application/libraries/Navigation.php
@@ -47,23 +47,18 @@ class Navigation
                 'show_condition'=>	1,
                 'parent'	    =>	0
             ),
-            2 => array(
-                'text'		    => 	'Gigs',
-                'link'		    => 	base_url() . 'gig',
-                'show_condition'=> 1,
-                'parent'	    =>	0
-            ),
+
             3 => array(
                 'text'		    => 	'Find a Gig',
                 'link'		    => 	base_url() . 'gig',
                 'show_condition'=> 1,
-                'parent'	    =>	2
+                'parent'	    =>	0
             ),
             4 => array(
                 'text'		    => 	'Post a Gig',
                 'link'		    => 	base_url() . 'gig/add',
                 'show_condition'=>	1,
-                'parent'	    =>	2
+                'parent'	    =>	0
             ),
             //links commented out(deemed non-essential to MVP) for possible reintigration in future iterations
             /*5 => array(
@@ -269,7 +264,7 @@ class Navigation
                     (strcasecmp($this->headerMenu[ $iterator ] [ 'text' ], $selected) == 0 ) ? $class = "active" : $class = "";
                     if($this->hasChildren($iterator))
                     {
-                        $class .= "dropdown";
+                        $class .= " dropdown";
                         $interfacePart .= "<li class=\"" . $class . "\">";
                         $interfacePart .= "<a href=\"" . $this->headerMenu [ $iterator ] [ 'link' ] . "\" class=\"dropdown-toggle\" data-toggle=\"dropdown\">";
                         $interfacePart .= $this->headerMenu [ $iterator ] [ 'text' ];
@@ -290,7 +285,8 @@ class Navigation
                         $interfacePart .= '</li>' . "\n";
                     }
                 }
-            } else {
+            } 
+            else {
                 die ( sprintf ( 'menu nr %s must be an array', $iterator ) );
             }
         }//end foreach


### PR DESCRIPTION
I removed the Gigs dropdown menu from the navbar and enabled the active class for Find a Gig and Post a Gig for the navbar.

Here is my link to the live site: http://sekllancr.dreamhosters.com/gig-central/