### PR TITLE
Bug welcome welcome page text 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*]
+charset = utf-8
+
+# Tab indentation (no size specified)
+indent_style = tab

--- a/application/views/welcome_page.php
+++ b/application/views/welcome_page.php
@@ -22,7 +22,7 @@
             <h1><i class="fa fa-search"></i></h1>
             <h3>Find a gig</h3>
             <div class="bar"></div>
-            <p>Are you looking for a gig that you can sharpen your dev skills? Find a gig to work on.</p>
+            <p>Are you looking for a gig that can help you sharpen your dev skills? Find out who has a gig available.</p>
         </div></div>
     </a>
 
@@ -32,7 +32,7 @@
             <h1><i class="fa fa-briefcase"></i></h1>
             <h3>Post a gig</h3>
             <div class="bar"></div>
-            <p>Are you hiring a developer who can help your website building? Share with us</p>
+            <p>Are you looking to hire a developer to help you build your website? Post your gig with us.</p>
         </div></div>
     </a>
 

--- a/application/views/welcome_page.php
+++ b/application/views/welcome_page.php
@@ -22,7 +22,8 @@
             <h1><i class="fa fa-search"></i></h1>
             <h3>Find a gig</h3>
             <div class="bar"></div>
-            <p>Are you looking for a gig that can help you sharpen your dev skills? Find out who has a gig available.</p>
+            <p>Are you looking for a gig that can help you sharpen your dev skills?</p>
+            <p>Find out who has a gig available.</p>
         </div></div>
     </a>
 
@@ -32,7 +33,8 @@
             <h1><i class="fa fa-briefcase"></i></h1>
             <h3>Post a gig</h3>
             <div class="bar"></div>
-            <p>Are you looking to hire a developer to help you build your website? Post your gig with us.</p>
+            <p>Are you looking to hire a developer to help you build your website? </p>
+            <p>Post your gig with us.</p>
         </div></div>
     </a>
 


### PR DESCRIPTION
Updates text in ‘find a gig’ and ‘post a gig’ section of welcome_page
Please review the link:
http://watthayo.com/gig-central/ 
Report:
https://docs.google.com/document/d/1MiVSBmlB8LPIwbHgQITNv6tw0Kr346HheXwLGu0lwUU/edit?usp=sharing 