### PR TITLE
fixed layout of recent gigs and map

### DIFF
--- a/public/css/custom_styles.css
+++ b/public/css/custom_styles.css
@@ -17,7 +17,7 @@ body {
 }
 
 h2 {
-    padding-bottom:2rem;
+    padding-bottom:1.25rem;
 }
 
 .text-xs-center {

--- a/public/css/custom_styles_index.css
+++ b/public/css/custom_styles_index.css
@@ -121,6 +121,7 @@ body{
     position: relative;
     float: left;
     overflow: auto;
+    height: 450px;
 }
 
 .inner-column{
@@ -131,6 +132,7 @@ body{
     border-radius: 4px;
     -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
     box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+    height: 440px;
 }
 
 .map-small{


### PR DESCRIPTION
I changed the height for the recent gigs and map sections to be equal to one another for a cleaner look.

working on my site: http://jonathonkindle.studio/ITC260-sp2020/gig-central/